### PR TITLE
Compatibility with rails 7

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -3,7 +3,9 @@ require "neat/generator"
 module Neat
   if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine
-      config.assets.paths << File.expand_path("../core", __dir__)
+      initializer "neat.paths", group: :all do |app|
+        app.config.assets.paths << File.expand_path("../core", __dir__)
+      end
     end
   else
     begin

--- a/lib/neat/version.rb
+++ b/lib/neat/version.rb
@@ -1,3 +1,3 @@
 module Neat
-  VERSION = "4.0.1"
+  VERSION = "4.0.2"
 end


### PR DESCRIPTION
taking inspiration from https://github.com/thoughtbot/bourbon/pull/1109

while efforts are underway to remove neat dependency in the 'shirtspace' repo the upgrade for rails 7 is looming. this patch to our forked version should allow us to be be able to upgrade to rails 7 without having to wait for a complete removal of the neat gem

